### PR TITLE
Add site-based IG accounts

### DIFF
--- a/src/components/layout/NavSocialLinks.tsx
+++ b/src/components/layout/NavSocialLinks.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { CurrentSite } from "../../lib/sites";
 import { styled, useStyletron } from "baseui";
 import { Row } from "../Row";
 
@@ -17,7 +18,7 @@ export const NavSocialLinks = () => {
   return (
     <Row>
       <NavSocialLink
-        href="https://instagram.com/togetherott"
+        href= {(CurrentSite.instagram)}
         target="_blank"
         rel="noopener"
         className={css({ marginRight: $theme.sizing.scale400 })}

--- a/src/lib/sites.ts
+++ b/src/lib/sites.ts
@@ -7,6 +7,7 @@ export interface SiteConfig {
   webflowID: string;
   algoliaAPIKey: string; // generated via /api/algoliaKeys
   googleAnalyticsID: string;
+  instagram: string;
 }
 
 export const CurrentSiteName = assert(process.env.CURRENT_SITE, "CURRENT_SITE environment variable needs to be set");
@@ -19,6 +20,7 @@ export const Sites: { [key: string]: SiteConfig } = {
     algoliaAPIKey:
       "MjA2ZmRjMWQxZTliNThkMGM1ZDcyMTMzY2MyZmQ3ZWI2ODRiODMxODRjMDdhMDNiZWUwNGU1Y2ZlYmQyNmNmN2ZpbHRlcnM9c2l0ZSUzQTVlOWI4MzkxZmVhZWJkYTUwYTY0NjhiOQ==",
     googleAnalyticsID: "UA-161950128-1",
+    instagram: "https://www.instagram.com/togetherott/",
   },
   outaouais: {
     rootURL: "https://outaouais.together-apart.ca",
@@ -28,6 +30,7 @@ export const Sites: { [key: string]: SiteConfig } = {
     algoliaAPIKey:
       "ZjdiNmI1MGMwMGM3NGY1ZjJiZWY4ZTcwOGY5OGQxNGUzYWUwMjJhNGY3NGRhMTUxODc2YWM4NTg2ZDZkMDg3ZWZpbHRlcnM9c2l0ZSUzQTVlOWI4M2EzM2VmNmRmZGFhYmY3MjQzNw==",
     googleAnalyticsID: "UA-161950128-2",
+    instagram: "https://www.instagram.com/togetherott/",
   },
   durham: {
     rootURL: "https://durham.together-apart.ca",
@@ -37,6 +40,7 @@ export const Sites: { [key: string]: SiteConfig } = {
     algoliaAPIKey:
       "ZDY0ZmEyMzI2MDdjNzQwMmEzZjliN2YyMWIyMjhkMDZjMjYwNzljOGZjYjBiNDBjNTUwYjQ4NWIxYTZiZGM2ZWZpbHRlcnM9c2l0ZSUzQTVlYTVjN2JmNTIzNDQ4NDdiNTMwZGU2Yw==",
     googleAnalyticsID: "UA-161950128-3",
+    instagram: "https://www.instagram.com/togetherdurham/",
   },
 };
 


### PR DESCRIPTION
This creates and `instagram` property on the sites within `SiteConfig`, to allow for individual IG accounts to be linked to the Together Apart IG icon on the site.